### PR TITLE
Fixing keyboard input for some games

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ An emulation of the ZX-Spectrum computer on an ESP32 chip with VGA output based 
 
 ## Compiling and installing
 
-At this point we only support GNU/Linux and MacOS/X. It may work at Windoze too but we don't know.
+GNU/Linux, MacOS/X and Windows supported.
 
 #### Install platformIO:
 
 - They have an extension for Atom and VSCode, and this is [the webpage](https://platformio.org/).
 - Select you board.
-- Install Bitluni's ESP32Lib.
+- Install Bitluni's ESP32Lib (use version 0.2.1, newer versions such as 0.3.3 will lead to compile errors)
 
 #### Softlink and customize platformio.ini
 
@@ -51,15 +51,15 @@ cp data/boot.cfg.orig boot.cfg
 
 #### Upload the data filesystem
 
-`Run Other Task > PIO Upload Filesystem Image`
+`PlatformIO > Project Tasks > Upload File System Image`
 
 #### Compile and flash it
 
-Right arrow at the bottom icon bar or `Tasks > Run Build Task > PlatformIO: Build` and `Tasks > PlatformIO: Upload`.
+Right arrow at the bottom icon bar or `PlatformIO > Project Tasks > Build` and `PlatformIO > Project Tasks > Upload`.
 
 ## Hardware configuration and pinout
 
-Comming soon...
+See pin assignment in include/def/hardware.h or change it to your own preference.
 
 ## Thanks to
 

--- a/src/z80main.cpp
+++ b/src/z80main.cpp
@@ -187,51 +187,23 @@ extern "C" uint8_t input(uint8_t portLow, uint8_t portHigh) {
     // delay(2);
     // Serial.print ("IN ");
     if (portLow == 0xFE) {
+
+        // EAR_PIN
+        if (portHigh == 0xFE) {
+            bitWrite(z80ports_in[0], 6, digitalRead(EAR_PIN));
+        }
+
         // Keyboard
-
-        switch (portHigh) {
-
-        case 0xfe:
-            kbdarrno = 0;
-            break;
-        case 0xfd:
-            kbdarrno = 1;
-            break;
-        case 0xfb:
-            kbdarrno = 2;
-            break;
-        case 0xf7:
-            kbdarrno = 3;
-            break;
-        case 0xef:
-            kbdarrno = 4;
-            break;
-        case 0xdf:
-            kbdarrno = 5;
-            break;
-        case 0xbf:
-            kbdarrno = 6;
-            break;
-        case 0x7f:
-            kbdarrno = 7;
-            break;
-
-        case 0x00: {
-            uint8_t result = z80ports_in[7];
-            result &= z80ports_in[6];
-            result &= z80ports_in[5];
-            result &= z80ports_in[4];
-            result &= z80ports_in[3];
-            result &= z80ports_in[2];
-            result &= z80ports_in[1];
-            result &= z80ports_in[0];
-            return result;
-        }
-        }
-        if (portHigh == 0xfe) {
-            bitWrite(z80ports_in[kbdarrno], 6, digitalRead(EAR_PIN));
-        }
-        return (z80ports_in[kbdarrno]);
+        uint8_t result = 0xFF;
+        if (~(portHigh | 0xFE)&0xFF) result &= z80ports_in[0];
+        if (~(portHigh | 0xFD)&0xFF) result &= z80ports_in[1];
+        if (~(portHigh | 0xFB)&0xFF) result &= z80ports_in[2];
+        if (~(portHigh | 0xF7)&0xFF) result &= z80ports_in[3];
+        if (~(portHigh | 0xEF)&0xFF) result &= z80ports_in[4];
+        if (~(portHigh | 0xDF)&0xFF) result &= z80ports_in[5];
+        if (~(portHigh | 0xBF)&0xFF) result &= z80ports_in[6];
+        if (~(portHigh | 0x7F)&0xFF) result &= z80ports_in[7];
+        return result;
     }
     // Kempston
     if (portLow == 0x1F) {


### PR DESCRIPTION
Hello, I'm working on a fork of your great project. I will be adding support for Wiimote (I have one sitting on a drawer :)

I have made a small change in the code which handles keyboard input which I thing makes it more general. It handles all cases your code did, and a few more.

Most games read keyboard state using individual ports (FE/FD/FB/F7/EF/DF/BF/7F). But other games different approaches. For example, Manic Miner from Matthew Smith reads port 7E (which happens to be a combination of FE and 7F) for using any key in the bottom row for jumping. This code handles ALL cases.

Regards and congratulations on your excellent work. This is the project I would have done myself if you hadn't done it before, and saved me all the work :)