### PR TITLE
Added support for VGA-32 v1.4 using #ifdef VGA32V14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ platformio.ini
 /work
 .piolibdeps/
 .vscode
+.pio
 data/boot.cfg
 data/sna/**
 !data/sna/sppong.sna

--- a/include/Disk.h
+++ b/include/Disk.h
@@ -21,7 +21,13 @@ extern String cfg_wssid;
 extern String cfg_wpass;
 
 // Declared methods
+
+#ifdef VGA32V14
+void IRAM_ATTR mount_sd();
+#else
 void IRAM_ATTR mount_spiffs();
+#endif
+
 String getAllFilesFrom(const String path);
 void listAllFiles();
 File IRAM_ATTR open_read_file(String filename);

--- a/include/MartianVGA.h
+++ b/include/MartianVGA.h
@@ -1,6 +1,4 @@
 #pragma once
 
 #include "VGA/VGA14Bit.h"
-#include "VGA/VGA14BitI.h"
 #include "VGA/VGA3Bit.h"
-#include "VGA/VGA3BitI.h"

--- a/include/def/hardware.h
+++ b/include/def/hardware.h
@@ -1,3 +1,25 @@
+#ifdef VGA32V14
+
+#define SPEAKER_PIN 25
+#define EAR_PIN 34
+#define MIC_PIN 39
+
+#define KEYBOARD_DATA 32
+#define KEYBOARD_CLK 33
+
+#define COLOUR_16
+
+// 16b pins
+#define RED_PINS 21, 21, 22, 22, 22
+#define GREEN_PINS 18, 18, 19, 19, 19
+#define BLUE_PINS 4, 4, 5, 5
+
+// VGA sync pins
+#define HSYNC_PIN 23
+#define VSYNC_PIN 15
+
+#else
+
 #define SPEAKER_PIN 5
 #define EAR_PIN 34
 #define MIC_PIN 0
@@ -21,6 +43,9 @@
 // VGA sync pins
 #define HSYNC_PIN 32
 #define VSYNC_PIN 33
+
+
+#endif
 
 #ifdef COLOUR_8
 #define BLACK 0x08

--- a/platformio.ini.vga32
+++ b/platformio.ini.vga32
@@ -1,0 +1,11 @@
+# Use this configuration to build for VGA32 v1.4
+
+[env:pico32]
+platform = espressif32
+board = pico32
+framework = arduino
+board_build.partitions = noota_3g.csv
+lib_deps = bitluni/bitluni ESP32Lib@0.2.1
+build_flags =
+    -DVGA32V14
+

--- a/src/ZX-ESPectrum.ino
+++ b/src/ZX-ESPectrum.ino
@@ -49,7 +49,12 @@ void setup_cpuspeed();
 void config_read();
 void do_OSD();
 void errorHalt(String);
+
+#ifdef VGA32V14
+void mount_sd();
+#else
 void mount_spiffs();
+#endif
 
 // GLOBALS
 volatile byte z80ports_in[128];
@@ -75,7 +80,6 @@ VGA3Bit vga;
 VGA14Bit vga;
 #endif
 
-
 void setup() {
     // Turn off peripherals to gain memory (?do they release properly)
     esp_bt_controller_deinit();
@@ -88,7 +92,12 @@ void setup() {
 
     Serial.printf("HEAP BEGIN %d\n", ESP.getFreeHeap());
 
+#ifdef VGA32V14
+    mount_sd();
+#else
     mount_spiffs();
+#endif
+
     config_read();
     // wifiConn();
     Serial.printf("HEAP AFTER WIFI %d\n", ESP.getFreeHeap());


### PR DESCRIPTION
Suggested changes to build for VGA32 v1.4 (see http://www.lilygo.cn/prod_view.aspx?TypeId=50033&Id=1083). Using SD card instead of SPIFFS and redefined all PINs. Rename platformio.ini.vga32 to platformio.ini and also use 48K mode.